### PR TITLE
Added user tracking endpoint for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ might break in future iOS versions or have your app rejected in the App Store.
 | **`Sounds`**                   | <code>'sounds'</code>                   | Used to set phone volume, vibration settings, etc.                                                                 |
 | **`SoftwareUpdate`**           | <code>'softwareUpdate'</code>           | Software update screen.                                                                                            |
 | **`Store`**                    | <code>'store'</code>                    | Store settings.                                                                                                    |
+| **`Tracking`**                 | <code>'tracking'</code>                 | Tracking settings.                                                                                                 |
 | **`Wallpaper`**                | <code>'wallpaper'</code>                | Wallpaper settings.                                                                                                |
 | **`WiFi`**                     | <code>'wifi'</code>                     | WiFi settings.                                                                                                     |
 | **`Tethering`**                | <code>'tethering'</code>                | Tethering settings (used to create a hotspot with mobile data).                                                    |

--- a/ios/Plugin/NativeSettingsPlugin.swift
+++ b/ios/Plugin/NativeSettingsPlugin.swift
@@ -26,6 +26,7 @@ public class NativeSettingsPlugin: CAPPlugin {
         "sounds": "App-prefs:Sounds",
         "softwareUpdate": "App-prefs:General&path=SOFTWARE_UPDATE_LINK",
         "store": "App-prefs:STORE",
+        "tracking": "App-prefs:Privacy&path=USER_TRACKING",
         "wallpaper": "App-prefs:Wallpaper",
         "wifi": "App-prefs:WIFI",
         "tethering": "App-prefs:INTERNET_TETHERING",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -383,6 +383,11 @@ export enum IOSSettings {
    * Store settings.
    */
   Store = 'store',
+  
+  /**
+   * Tracking settings.
+   */
+  Tracking = 'tracking',
 
   /**
    * Wallpaper settings.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -133,7 +133,7 @@ export enum AndroidSettings {
   Home = 'home',
 
   /**
-   * 	Show settings to configure input methods, in particular allowing the user to enable input methods
+   *    Show settings to configure input methods, in particular allowing the user to enable input methods
    */
   Keyboard = 'keyboard',
 
@@ -153,7 +153,7 @@ export enum AndroidSettings {
   Location = 'location',
 
   /**
-   * 	Show settings to manage installed applications
+   *    Show settings to manage installed applications
    */
   ManageApplications = 'manage_applications',
 
@@ -383,7 +383,7 @@ export enum IOSSettings {
    * Store settings.
    */
   Store = 'store',
-  
+
   /**
    * Tracking settings.
    */


### PR DESCRIPTION
Tracking endpoint is needed on occassions like activating App Tracking Transparency on iOS.