### PR TITLE
Update CapacitorNativeSettings.podspec

### DIFF
--- a/CapacitorNativeSettings.podspec
+++ b/CapacitorNativeSettings.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author = package['author']
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-  s.ios.deployment_target  = '12.0'
+  s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.1'
 end


### PR DESCRIPTION
Still getting the following errors when using this dependency with Capacitor 4 -- shouldn't the podspec also be bumped to target 13?

Thrown during build:

`NativeSettingsPlugin.swift:2:8: compiling for iOS 12.0, but module 'Capacitor' has a minimum deployment target of iOS 13.0: /Users/ionic-cloud-team/Library/Developer/Xcode/DerivedData/App-bcnhnmaahexbnydurxfgfrwwvhxn/Build/Intermediates.noindex/ArchiveIntermediates/App/BuildProductsPath/Release-iphoneos/Capacitor/Capacitor.framework/Modules/Capacitor.swiftmodule/arm64-apple-ios.swiftmodule`