### PR TITLE
adds activityResult to improve promise usability on Android

### DIFF
--- a/android/src/main/java/nl/raphael/settings/NativeSettingsPlugin.java
+++ b/android/src/main/java/nl/raphael/settings/NativeSettingsPlugin.java
@@ -6,10 +6,12 @@ import static android.provider.Settings.EXTRA_APP_PACKAGE;
 
 import android.content.Intent;
 import android.net.Uri;
+import androidx.activity.result.ActivityResult;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.ActivityCallback;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
 @CapacitorPlugin(name = "NativeSettings")
@@ -57,12 +59,15 @@ public class NativeSettingsPlugin extends Plugin {
             intent.setAction(setting);
         }
 
-        // Start intent in activity.
-        getActivity().startActivity(intent);
+        startActivityForResult(call, intent, "activityResult");
 
-        // Send response.
+    }
+
+    @ActivityCallback
+    private void activityResult(PluginCall call, ActivityResult result) {
         JSObject js = new JSObject();
         js.put("status", true);
         call.resolve(js);
     }
+
 }

--- a/android/src/main/java/nl/raphael/settings/NativeSettingsPlugin.java
+++ b/android/src/main/java/nl/raphael/settings/NativeSettingsPlugin.java
@@ -60,7 +60,6 @@ public class NativeSettingsPlugin extends Plugin {
         }
 
         startActivityForResult(call, intent, "activityResult");
-
     }
 
     @ActivityCallback
@@ -69,5 +68,4 @@ public class NativeSettingsPlugin extends Plugin {
         js.put("status", true);
         call.resolve(js);
     }
-
 }

--- a/android/src/main/java/nl/raphael/settings/NativeSettingsPlugin.java
+++ b/android/src/main/java/nl/raphael/settings/NativeSettingsPlugin.java
@@ -62,6 +62,9 @@ public class NativeSettingsPlugin extends Plugin {
         startActivityForResult(call, intent, "activityResult");
     }
 
+    /**
+     * Send response on activityResult (when intent closes)
+     */
     @ActivityCallback
     private void activityResult(PluginCall call, ActivityResult result) {
         JSObject js = new JSObject();


### PR DESCRIPTION
Adds usability to then promise in the method NativeSettings.open

Platform:

Android
```

testMethod = () => {
    const options = {
      optionAndroid: AndroidSettings.ApplicationDetails,
      optionIOS: IOSSettings.App,
    };
    /**
     * Current Behavior: Then promise execute immediately
     * New Behavior: Then promise wait to user gets back to screen
     */
    NativeSettings.open(options).then((data) => {
      this.presentAlert('then execution', JSON.stringify(data), '');
    });
  };
```

https://user-images.githubusercontent.com/6577163/232974748-83e1f0f7-d999-4a7d-9c2e-e447c199fbea.mp4


