### PR TITLE
Fix return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Provides access to native Android and iOS system settings screens.
 ### open(...)
 
 ```typescript
-open(options: PlatformOptions) => Promise<{ status: boolean; }>
+open(options: PlatformOptions) => Promise<{ success: boolean; }>
 ```
 
 Opens the specified settings option on the current platform.
@@ -84,7 +84,7 @@ Opens the specified settings option on the current platform.
 | ------------- | ----------------------------------------------------------- | ----------------------------------- |
 | **`options`** | <code><a href="#platformoptions">PlatformOptions</a></code> | Platform-specific settings options. |
 
-**Returns:** <code>Promise&lt;{ status: boolean; }&gt;</code>
+**Returns:** <code>Promise&lt;{ success: boolean; }&gt;</code>
 
 --------------------
 
@@ -92,7 +92,7 @@ Opens the specified settings option on the current platform.
 ### openAndroid(...)
 
 ```typescript
-openAndroid(options: AndroidOptions) => Promise<{ status: boolean; }>
+openAndroid(options: AndroidOptions) => Promise<{ success: boolean; }>
 ```
 
 Opens the specified Android settings screen.
@@ -101,7 +101,7 @@ Opens the specified Android settings screen.
 | ------------- | --------------------------------------------------------- | ------------------------- |
 | **`options`** | <code><a href="#androidoptions">AndroidOptions</a></code> | Android settings options. |
 
-**Returns:** <code>Promise&lt;{ status: boolean; }&gt;</code>
+**Returns:** <code>Promise&lt;{ success: boolean; }&gt;</code>
 
 --------------------
 
@@ -109,7 +109,7 @@ Opens the specified Android settings screen.
 ### openIOS(...)
 
 ```typescript
-openIOS(options: IOSOptions) => Promise<{ status: boolean; }>
+openIOS(options: IOSOptions) => Promise<{ success: boolean; }>
 ```
 
 Opens the specified iOS settings screen.
@@ -118,7 +118,7 @@ Opens the specified iOS settings screen.
 | ------------- | ------------------------------------------------- | --------------------- |
 | **`options`** | <code><a href="#iosoptions">IOSOptions</a></code> | iOS settings options. |
 
-**Returns:** <code>Promise&lt;{ status: boolean; }&gt;</code>
+**Returns:** <code>Promise&lt;{ success: boolean; }&gt;</code>
 
 --------------------
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -10,7 +10,7 @@ export interface NativeSettingsPlugin {
    * @param options Platform-specific settings options.
    * @returns A promise resolving to the operation result.
    */
-  open(options: PlatformOptions): Promise<{ status: boolean }>;
+  open(options: PlatformOptions): Promise<{ success: boolean }>;
 
   /**
    * Opens the specified Android settings screen.
@@ -18,7 +18,7 @@ export interface NativeSettingsPlugin {
    * @param options Android settings options.
    * @returns A promise resolving to the operation result.
    */
-  openAndroid(options: AndroidOptions): Promise<{ status: boolean }>;
+  openAndroid(options: AndroidOptions): Promise<{ success: boolean }>;
 
   /**
    * Opens the specified iOS settings screen.
@@ -30,7 +30,7 @@ export interface NativeSettingsPlugin {
    * @param options iOS settings options.
    * @returns A promise resolving to the operation result.
    */
-  openIOS(options: IOSOptions): Promise<{ status: boolean }>;
+  openIOS(options: IOSOptions): Promise<{ success: boolean }>;
 }
 
 /**

--- a/src/web.ts
+++ b/src/web.ts
@@ -9,19 +9,19 @@ import type { NativeSettingsPlugin } from './definitions';
  * This plugin is not supported on the web platform.
  */
 export class NativeSettingsWeb extends WebPlugin implements NativeSettingsPlugin {
-  async open(): Promise<{ status: boolean }> {
+  async open(): Promise<{ success: boolean }> {
     return new Promise<any>((_resolve, reject) => {
       reject(new Error('Not implemented for web.'));
     });
   }
 
-  async openAndroid(): Promise<{ status: boolean }> {
+  async openAndroid(): Promise<{ success: boolean }> {
     return new Promise<any>((_resolve, reject) => {
       reject(new Error('Not implemented for web.'));
     });
   }
 
-  async openIOS(): Promise<{ status: boolean }> {
+  async openIOS(): Promise<{ success: boolean }> {
     return new Promise<any>((_resolve, reject) => {
       reject(new Error('Not implemented for web.'));
     });


### PR DESCRIPTION
Currently the code suggests that open returns 
```
Promise<{
        status: boolean;
    }>
```

but the code returns in Android
```
        response.put("success", true);
```
and in iOS
```
               call.resolve([
                    "success": success
                ])
```

So I assume the return value should be 
```
Promise<{
        success: boolean;
    }>
```

Hope I did not miss something.